### PR TITLE
Replace external placeholder images with local assets

### DIFF
--- a/src/components/01-atoms/images/image-responsive/image-responsive.config.json
+++ b/src/components/01-atoms/images/image-responsive/image-responsive.config.json
@@ -1,7 +1,7 @@
 {
   "status": "ready",
   "context": {
-    "src": "https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240",
+    "src": "/assets/img/picture-540x360.jpg",
     "alt": "Alternative text"
   }
 }

--- a/src/components/01-atoms/images/image/image.config.json
+++ b/src/components/01-atoms/images/image/image.config.json
@@ -1,28 +1,28 @@
 {
   "status": "ready",
   "context": {
-    "src": "https://placehold.it/960x640/ea09ff/000001?text=Default|960x640",
+    "src": "/assets/img/picture-960x640.jpg",
     "alt": "Alternative text",
     "srcset": [
       {
         "width": "320w",
-        "file": "https://placehold.it/320x210/d8e7ff/000001?text=320x210"
+        "file": "/assets/img/picture-320x213.jpg"
       },
       {
         "width": "540w",
-        "file": "https://placehold.it/540x360/a4c6fc/000001?text=540x360"
+        "file": "/assets/img/picture-540x360.jpg"
       },
       {
         "width": "720w",
-        "file": "https://placehold.it/720x480/6ba4ff/000001?text=720x480"
+        "file": "/assets/img/picture-720x480.jpg"
       },
       {
         "width": "960w",
-        "file": "https://placehold.it/960x640/3f89ff/000001?text=960x640"
+        "file": "/assets/img/picture-960x640.jpg"
       },
       {
         "width": "1140w",
-        "file": "https://placehold.it/1140x760/0a68ff/fffffa?text=1140x760"
+        "file": "/assets/img/picture-1140x760.jpg"
       }
     ]
   },

--- a/src/components/02-molecules/authorities-news/authorities-news.html
+++ b/src/components/02-molecules/authorities-news/authorities-news.html
@@ -18,7 +18,7 @@
     <div class="vd-reel mt-5">
       {%- for news in newsList -%}
         <a href="{{ news.url }}" class="card text-decoration-none">
-          <img alt="{files.0.alternative}" class="img-fluid" loading="lazy" height="240" src="http://placehold.it/240x400" width="400" title="Title" />
+          <img alt="{files.0.alternative}" class="img-fluid" loading="lazy" height="240" src="/assets/img/picture-540x360.jpg" width="400" title="Title" />
           <div class="card-body">
             <h5 class="card-title">{{ news.title }}</h5>
             <p class="card-text">{{ news.text }}</p>

--- a/src/components/02-molecules/media/figure/figure.config.json
+++ b/src/components/02-molecules/media/figure/figure.config.json
@@ -17,15 +17,15 @@
           "source": [
             {
               "media": "(min-width: 60em)",
-              "srset": "http://placehold.it/1600x1067/ACCBE8/ffffff?text=eXtra Large|1600x1067"
+              "srset": "/assets/img/picture-1600x1067.jpg"
             },
             {
               "media": "(min-width: 40em)",
-              "srset": "http://placehold.it/960x640/ACCBE8/ffffff?text=Large|960x640"
+              "srset": "/assets/img/picture-960x640.jpg"
             },
             {
               "media": "(min-width: 20em)",
-              "srset": "http://placehold.it/640x427/F1BF9F/ffffff?text=Medium|640x427"
+              "srset": "/assets/img/picture-540x360.jpg"
             }
           ],
           "src": "@image--fluid.src",

--- a/src/components/02-molecules/nowcard/nowcard.html
+++ b/src/components/02-molecules/nowcard/nowcard.html
@@ -4,7 +4,7 @@
       {%- for image in images -%}
         <a href="{{ image.url }}" class="col-12 col-sm-3 mt-3 text-black">
           <div class="item">
-            <img src="http://placehold.it/250x250" class="img-fluid" height="250" width="250" />
+            <img src="/assets/img/picture-320x213.jpg" class="img-fluid" height="250" width="250" />
             <p class="mb-2 mt-2">{{ image.title }}</p>
             <i class="fa fa-arrow-right"></i>
           </div>

--- a/src/components/02-molecules/teaser/teaser-card/teaser-card.html
+++ b/src/components/02-molecules/teaser/teaser-card/teaser-card.html
@@ -1,5 +1,5 @@
 <div class="card vd-teaser-card {% if styleModifier %}{{ styleModifier }}{% else %}vd-card-lightgray{% endif %}">
-  <img class="card-img-top w-100" src="http://placehold.it/700x200" alt="Card image cap">
+  <img class="card-img-top w-100" src="/assets/img/picture-720x480.jpg" alt="Card image cap">
   <div class="card-body">
     <h4 class="card-title mt-0">Card title</h4>
     <p class="card-text">Some quick example text to build on the card title and

--- a/src/components/03-organisms/autorities-news/autorities-news.html
+++ b/src/components/03-organisms/autorities-news/autorities-news.html
@@ -22,42 +22,42 @@
   </div>
   <div class="vd-reel mt-5">
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>
       </div>
     </a>
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>
       </div>
     </a>
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>
       </div>
     </a>
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>
       </div>
     </a>
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>
       </div>
     </a>
     <a href="#" class="card text-decoration-none">
-      <img class="card-img-top" src="https://placehold.it/360x240/F1BF9F/ffffff?text=Default|360x240">
+      <img class="card-img-top" src="/assets/img/picture-540x360.jpg">
       <div class="card-body">
         <h5 class="card-title">Vaccination contre le covid</h5>
         <p class="card-text">Lorem ipsum Lorem ipsum</p>

--- a/src/components/03-organisms/autority-address/autority-address.html
+++ b/src/components/03-organisms/autority-address/autority-address.html
@@ -80,8 +80,8 @@
 
   {% if image -%}
   <img class="img-fluid"
-       src="https://placehold.it/960x640/ea09ff/000001?text=Default|960x640"
-       srcset="https://placehold.it/320x210/d8e7ff/000001?text=320x210 320w, https://placehold.it/540x360/a4c6fc/000001?text=540x360 540w, https://placehold.it/720x480/6ba4ff/000001?text=720x480 720w, https://placehold.it/960x640/3f89ff/000001?text=960x640 960w, https://placehold.it/1140x760/0a68ff/fffffa?text=1140x760 1140w"
+       src="/assets/img/picture-960x640.jpg"
+       srcset="/assets/img/picture-320x213.jpg 320w, /assets/img/picture-540x360.jpg 540w, /assets/img/picture-720x480.jpg 720w, /assets/img/picture-960x640.jpg 960w, /assets/img/picture-1140x760.jpg 1140w"
        alt="Alternative text"
        itemprop="image">
   {%- endif %}

--- a/src/components/04-templates/communiques-presse/template-communiques-presse-detail.config.json
+++ b/src/components/04-templates/communiques-presse/template-communiques-presse-detail.config.json
@@ -30,27 +30,27 @@
       "partners": [
         {
           "name": "Partenaire",
-          "src": "http://placehold.it/75x75",
+          "src": "/assets/img/picture-320x213.jpg",
           "alt": "logo du partenaire"
         },
         {
           "name": "Partenaire",
-          "src": "http://placehold.it/75x75",
+          "src": "/assets/img/picture-320x213.jpg",
           "alt": "logo du partenaire"
         },
         {
           "name": "Partenaire",
-          "src": "http://placehold.it/75x75",
+          "src": "/assets/img/picture-320x213.jpg",
           "alt": "logo du partenaire"
         },
         {
           "name": "Partenaire",
-          "src": "http://placehold.it/75x75",
+          "src": "/assets/img/picture-320x213.jpg",
           "alt": "logo du partenaire"
         },
         {
           "name": "Partenaire",
-          "src": "http://placehold.it/75x75",
+          "src": "/assets/img/picture-320x213.jpg",
           "alt": "logo du partenaire"
         }
       ],
@@ -74,17 +74,17 @@
           "partners": [
             {
               "name": "Partenaire",
-              "src": "http://placehold.it/75x75",
+              "src": "/assets/img/picture-320x213.jpg",
               "alt": "logo du partenaire"
             },
             {
               "name": "Partenaire",
-              "src": "http://placehold.it/75x75",
+              "src": "/assets/img/picture-320x213.jpg",
               "alt": "logo du partenaire"
             },
             {
               "name": "Partenaire",
-              "src": "http://placehold.it/75x75",
+              "src": "/assets/img/picture-320x213.jpg",
               "alt": "logo du partenaire"
             }
           ]


### PR DESCRIPTION
## Summary
- Replace all external placehold.it service URLs with local images from /assets/img/
- Update image references across components to use local picture-*.jpg files
- Maintain responsive image behavior with proper srcset attributes

## Test plan
- [x] Verify all components build successfully
- [x] Check that local images load properly in component previews
- [x] Confirm responsive image behavior is maintained